### PR TITLE
use jnuit5 parameterized test with csv file

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,11 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+        }
+    }
 }
 
 dependencies {
@@ -37,7 +42,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.6.0'
     implementation 'org.jetbrains.kotlin:kotlin-reflect:1.6.21'
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/app/src/test/resources/paths.csv
+++ b/app/src/test/resources/paths.csv
@@ -1,0 +1,1 @@
+src/main/java/com/example/testreflection/old/DummyClass.kt,src/main/java/com/example/testreflection/dup/DummyClass.kt


### PR DESCRIPTION
This PR makes the unit test more scalable. The approach is to read old file paths and new file paths from a csv file and compare all of the pairs in a single unit test.